### PR TITLE
Changed apt-get to apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 -----
 
 ```
-sudo apt-get install build-essential libgtop2-dev libgtk-3-dev libappindicator3-dev git-core
+sudo apt install build-essential libgtop2-dev libgtk-3-dev libappindicator3-dev git-core
 git clone https://github.com/kerollosasaad/Indicator-memory
 cd Indicator-memory
 make


### PR DESCRIPTION
The diff below shows two line modifications, the latter is not really modified.

You can use the apt command instead of apt-get and it is recommended by the apt developers. So I've changed it here.
